### PR TITLE
allow cli to modify default and custom config

### DIFF
--- a/cmd/config.add.tokens.go
+++ b/cmd/config.add.tokens.go
@@ -1,8 +1,12 @@
 package cmd
 
 import (
+	"fmt"
+	"path/filepath"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/tywil04/slavartdl/internal/config"
 )
 
 var configAddTokensCmd = &cobra.Command{
@@ -10,13 +14,37 @@ var configAddTokensCmd = &cobra.Command{
 	Short:        "Adds session token to config",
 	SilenceUsage: true,
 	Args:         cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
+		flags := cmd.Flags()
+
+		// optional
+		configPathRel, err := flags.GetString("configPath")
+		if err != nil {
+			return fmt.Errorf("unknown error when getting '--configPath'")
+		}
+
+		configPath, err := filepath.Abs(configPathRel)
+		if err != nil {
+			return fmt.Errorf("failed to resolve relative 'configPath' into absolute path")
+		}
+
+		// load config
+		if err := config.Load(configPathRel == "", configPath); err != nil {
+			return fmt.Errorf("failed to load config")
+		}
+
 		sessionTokens := viper.GetStringSlice("divoltsessiontokens")
 		sessionTokens = append(sessionTokens, args...)
 		viper.Set("divoltsessiontokens", sessionTokens)
+
+		return nil
 	},
 }
 
 func init() {
+	flags := configAddTokensCmd.Flags()
+
+	flags.StringP("configPath", "C", "", "a directory that contains an override config.json file\nor a file which contains an override config")
+
 	configAddCmd.AddCommand(configAddTokensCmd)
 }

--- a/cmd/config.list.tokens.go
+++ b/cmd/config.list.tokens.go
@@ -2,23 +2,49 @@ package cmd
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/tywil04/slavartdl/internal/config"
 )
 
 var configListTokensCmd = &cobra.Command{
 	Use:   "tokens [flags]",
 	Short: "Lists stored session tokens",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
+		flags := cmd.Flags()
+
+		// optional
+		configPathRel, err := flags.GetString("configPath")
+		if err != nil {
+			return fmt.Errorf("unknown error when getting '--configPath'")
+		}
+
+		configPath, err := filepath.Abs(configPathRel)
+		if err != nil {
+			return fmt.Errorf("failed to resolve relative 'configPath' into absolute path")
+		}
+
+		// load config
+		if err := config.Load(configPathRel == "", configPath); err != nil {
+			return fmt.Errorf("failed to load config")
+		}
+
 		sessionTokens := viper.GetStringSlice("divoltsessiontokens")
 
 		for index, token := range sessionTokens {
 			fmt.Printf("[%d]: %s\n", index, token)
 		}
+
+		return nil
 	},
 }
 
 func init() {
+	flags := configListTokensCmd.Flags()
+
+	flags.StringP("configPath", "C", "", "a directory that contains an override config.json file\nor a file which contains an override config")
+
 	configListCmd.AddCommand(configListTokensCmd)
 }

--- a/cmd/config.remove.tokens.go
+++ b/cmd/config.remove.tokens.go
@@ -1,10 +1,13 @@
 package cmd
 
 import (
+	"fmt"
+	"path/filepath"
 	"strconv"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/tywil04/slavartdl/internal/config"
 )
 
 var configRemoveTokensCmd = &cobra.Command{
@@ -12,7 +15,25 @@ var configRemoveTokensCmd = &cobra.Command{
 	Short:        "Removes session token using index shown by the list command",
 	SilenceUsage: true,
 	Args:         cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
+		flags := cmd.Flags()
+
+		// optional
+		configPathRel, err := flags.GetString("configPath")
+		if err != nil {
+			return fmt.Errorf("unknown error when getting '--configPath'")
+		}
+
+		configPath, err := filepath.Abs(configPathRel)
+		if err != nil {
+			return fmt.Errorf("failed to resolve relative 'configPath' into absolute path")
+		}
+
+		// load config
+		if err := config.Load(configPathRel == "", configPath); err != nil {
+			return fmt.Errorf("failed to load config")
+		}
+
 		sessionTokens := viper.GetStringSlice("divoltsessiontokens")
 
 		for index := range sessionTokens {
@@ -28,9 +49,15 @@ var configRemoveTokensCmd = &cobra.Command{
 		}
 
 		viper.Set("divoltsessiontokens", sessionTokens)
+
+		return nil
 	},
 }
 
 func init() {
+	flags := configRemoveTokensCmd.Flags()
+
+	flags.StringP("configPath", "C", "", "a directory that contains an override config.json file\nor a file which contains an override config")
+
 	configRemoveCmd.AddCommand(configRemoveTokensCmd)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,19 +52,19 @@ func Load(defaultHandling bool, customPath string) error {
 			}
 
 			var defaultConfig = bytes.NewBuffer([]byte(`{
-"divoltSessionTokens": [],
-"downloadCmd": {
-	"outputDir": "",
-	"quality": 0,
-	"timeout": {
-		"seconds": 0,
-		"minutes": 2
-	},
-	"ignore": {
-		"cover": false,
-		"subdirs": false
+	"divoltsessiontokens": [],
+	"downloadcmd": {
+		"outputdir": "",
+		"quality": 0,
+		"timeout": {
+			"seconds": 0,
+			"minutes": 2
+		},
+		"ignore": {
+			"cover": false,
+			"subdirs": false
+		},
 	}
-}
 }`))
 
 			if err := viper.ReadConfig(defaultConfig); err != nil {

--- a/main.go
+++ b/main.go
@@ -1,13 +1,18 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
+	"github.com/spf13/viper"
 	"github.com/tywil04/slavartdl/cmd"
 )
 
 func main() {
 	if err := cmd.Execute(); err != nil {
+		if err := viper.WriteConfig(); err != nil {
+			fmt.Printf("Error: %s\n", err)
+		}
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
I (stupidly) forgot to add the code that allows commands to access either default or provided config to the commands that modify the config, plus I didn't enable viper to write once the command has finished execution. This is now fixed.

Part of https://github.com/tywil04/slavartdl/pull/5